### PR TITLE
fix: updated normalize url functon

### DIFF
--- a/Backend/src/demoWebsiteAnalysisFunction.js
+++ b/Backend/src/demoWebsiteAnalysisFunction.js
@@ -668,6 +668,7 @@ const normalizeUrl = (url) => {
   return url
     .replace(/^https?:\/\//, "") // Remove protocol (http:// or https://)
     .replace(/^www\./, "") // Remove "www." if it exists
+    .replace(/\/+$/, "") // Remove trailing slashes
     .toLowerCase(); // Convert the URL to lowercase
 };
 


### PR DESCRIPTION
- updated normalized url function so it can remove trailing '/' from urls example https://www.getgsi.com/ to getgsi.com, other functionality existed previously

